### PR TITLE
Patch/update split variables

### DIFF
--- a/examples/commonjs/App.vue
+++ b/examples/commonjs/App.vue
@@ -7,9 +7,9 @@
                 :firstname="firstname"
                 :lastname="lastname"
                 :accessCode="accessCode"
-                :ref="reference"
+                :splitCode="splitCode"
                 :paystackkey="paystackkey"
-                :reference="reference"
+                :reference="genReference"
                 :callback="callback"
                 :close="close"
                 :embed="false"
@@ -31,10 +31,9 @@ export default {
           paystackkey: "pk_test_xxxxxxxxxxxxxxxxxxxxxxx",
           firstname: "Foo",
           lastname: "Bar",
-          email: "foobar@example.com",
-          amount: 1000000,
-          accessCode: "example-access-code",
-          reference: "example-reference",
+          email: "foo@bar.com",
+          amount: 2000000,
+          splitCode: "",
           channels: ['card']
         }
     },

--- a/src/paystack.vue
+++ b/src/paystack.vue
@@ -162,8 +162,8 @@ export default {
                 plan: this.plan,
                 quantity: this.quantity,
                 subaccount: this.subaccount,
-                split_code: this.split_code,
-                transaction_charge: this.transaction_charge,
+                split_code: this.splitCode,
+                transaction_charge: this.transactionCharge,
                 bearer: this.bearer
             };
 


### PR DESCRIPTION
The split code and the transaction charge variables weren't being sent for split payment. This PR fixes that.